### PR TITLE
Fixes UI bug where would attempt to render view if a submenu heading was selected

### DIFF
--- a/src/main/java/app/AppMainPresenter.java
+++ b/src/main/java/app/AppMainPresenter.java
@@ -20,6 +20,8 @@ public class AppMainPresenter {
         appMainView = new AppMainView(leftNav);
         leftNavPresenter.addNavigationListener((leftNavItem) -> {
             JComponent newView = buildView(leftNavItem);
+            // null when a sub-menu heading is clicked
+            if (newView == null) return;
             appMainView.renderCard(leftNavItem, newView);
         });
     }
@@ -34,6 +36,7 @@ public class AppMainPresenter {
      *
      * @param navItem The navigation item to build the view for.
      * @return The view corresponding to the navigation item wired up to the presenter.
+     * null if a submenu heading is clicked or the specified view does not exist.
      */
     private JComponent buildView(LeftNavItem navItem) {
         return switch (navItem) {
@@ -45,7 +48,7 @@ public class AppMainPresenter {
             case VIEW_SINGLE_MEAL -> new PlaceholderView("Single Meal View");
             case VIEW_MEAL_STATISTICS -> new PlaceholderView("Meal Statistics View");
             case EXPLORE_INGREDIENT_SWAPS -> new PlaceholderView("Explore Swaps View");
-            default -> new PlaceholderView("Unknown View");
+            default -> null;
         };
     }
 


### PR DESCRIPTION
### Description

Currently, if you click on a sub-menu heading in the left nav, an "Unknown View" placeholder view is rendered. This PR addresses this issue, and does not attempt to render a new view if a sub-menu is selected.

### Testing

Running the app and double-clicking "Profiles", gives:

**Before**

<img width="2952" height="1272" alt="Screenshot 2025-07-20 211955" src="https://github.com/user-attachments/assets/d7d00438-4aa0-4cb9-b58f-df3ccda2dac8" />


**After**

<img width="2949" height="1182" alt="Screenshot 2025-07-20 211836" src="https://github.com/user-attachments/assets/b2c935aa-0028-4384-8a8c-97f989585e41" />

