### PR TITLE
Nutrition services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,11 @@ WORKDIR /app
 # copy file used by Maven for build
 COPY pom.xml .
 
+# copy script to run as entrypoint
+COPY docker-entrypoint.sh .
+
 # copy source code
 COPY src ./src
 
 # run tests
-ENTRYPOINT ["mvn", "clean", "test"]
+ENTRYPOINT ["sh", "./docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "Loading CSV files"
+mvn clean compile exec:java -Dexec.mainClass="csv.LoadNutritionDataService" -e
+
+echo "Running tests"
+mvn clean test

--- a/src/main/java/data/create-database.sql
+++ b/src/main/java/data/create-database.sql
@@ -36,10 +36,10 @@ CREATE TABLE meals
 -- One item within a meal
 CREATE TABLE meal_items
 (
-    id       INT PRIMARY KEY AUTO_INCREMENT,
-    meal_id  INT,
-    food_id  INT   NOT NULL,
-    quantity FLOAT NOT NULL,
+    id         INT PRIMARY KEY AUTO_INCREMENT,
+    meal_id    INT,
+    food_id    INT   NOT NULL,
+    quantity   FLOAT NOT NULL,
     -- TO DO: disabling NOT NULL check until the create meal service is updated
     -- to include the measure ID when saving a record to the database
     measure_id INT,
@@ -93,7 +93,7 @@ CREATE TABLE nutrient_amounts
 -- Food measurement (ex. "1 Cup")
 CREATE TABLE measures
 (
-    id  INT PRIMARY KEY,
+    id          INT PRIMARY KEY,
     common_name VARCHAR(255)
 );
 
@@ -108,3 +108,12 @@ CREATE TABLE conversion_factors
     FOREIGN KEY (food_id) REFERENCES foods (id),
     FOREIGN KEY (measure_id) REFERENCES measures (id)
 );
+
+-- View to get conversion factors and measure name in single query
+CREATE VIEW conversion_factors_with_measure_details AS
+SELECT cf.food_id AS food_id,
+       cf.measure_id AS measure_id,
+       m.common_name AS measure_name,
+       cf.conversion_factor_value AS conversion_factor_value
+FROM conversion_factors cf
+JOIN measures m ON cf.measure_id = m.id

--- a/src/main/java/meals/models/food/Food.java
+++ b/src/main/java/meals/models/food/Food.java
@@ -10,11 +10,17 @@ import java.util.Map;
  * Demonstrates the "has-a" relationship where Food can have a FoodGroup.
  */
 public class Food {
+    private static final String TABLE_NAME = "foods";
+
     private Integer foodId;
     private String foodDescription;
     private FoodGroup foodGroup;
     private Map<Nutrient, Float> nutrientAmounts;
     private List<Measure> possibleMeasures;
+
+    public static String getTableName() {
+        return TABLE_NAME;
+    }
 
     /**
      * Constructor with food group (aggregation).

--- a/src/main/java/meals/models/food/FoodGroup.java
+++ b/src/main/java/meals/models/food/FoodGroup.java
@@ -12,6 +12,9 @@ public class FoodGroup {
     private Integer foodGroupId;
     private String foodGroupName;
 
+    /**
+     * @return The table name for food groups.
+     */
     public static String getTableName() {
         return TABLE_NAME;
     }
@@ -24,16 +27,24 @@ public class FoodGroup {
         this.foodGroupName = foodGroupName;
     }
 
+    /**
+     * @param record The database record to use to construct a food group.
+     */
     public FoodGroup(IRecord record) {
         this.foodGroupId = (int) record.getValue("id");
         this.foodGroupName = (String) record.getValue("name");
     }
 
-    // Getters and setters
+    /**
+     * @return The unique identifier of the food group.
+     */
     public Integer getFoodGroupId() {
         return foodGroupId;
     }
 
+    /**
+     * @return The name of the food group.
+     */
     public String getFoodGroupName() {
         return foodGroupName;
     }

--- a/src/main/java/meals/models/food/FoodGroup.java
+++ b/src/main/java/meals/models/food/FoodGroup.java
@@ -1,12 +1,20 @@
 package meals.models.food;
 
+import data.IRecord;
+
 /**
  * Represents a food group entity (e.g., "Dairy and Egg Products", "Fruits and fruit juices").
  * This class implements IRecord to integrate with the database layer.
  */
 public class FoodGroup {
+    private static final String TABLE_NAME = "food_groups";
+
     private Integer foodGroupId;
     private String foodGroupName;
+
+    public static String getTableName() {
+        return TABLE_NAME;
+    }
 
     /**
      * Constructor for creating a food group with all details.
@@ -14,6 +22,11 @@ public class FoodGroup {
     public FoodGroup(Integer foodGroupId, String foodGroupName) {
         this.foodGroupId = foodGroupId;
         this.foodGroupName = foodGroupName;
+    }
+
+    public FoodGroup(IRecord record) {
+        this.foodGroupId = (int) record.getValue("id");
+        this.foodGroupName = (String) record.getValue("name");
     }
 
     // Getters and setters

--- a/src/main/java/meals/models/food/Measure.java
+++ b/src/main/java/meals/models/food/Measure.java
@@ -13,14 +13,9 @@ public class Measure {
     private final String name;
     private final float conversionValue;
 
-    public static String getMeasuresTableName() {
-        return MEASURES_TABLE_NAME;
-    }
-
-    public static String getConversionFactorsTableName() {
-        return CONVERSION_FACTORS_TABLE_NAME;
-    }
-
+    /**
+     * @return The name of the table containing conversion factors and their associated measure name.
+     */
     public static String getConversionFactorsMeasuresTableName() {
         return MEASURES_CONVERSION_FACTORS_VIEW_NAME;
     }

--- a/src/main/java/meals/models/food/Measure.java
+++ b/src/main/java/meals/models/food/Measure.java
@@ -5,10 +5,25 @@ package meals.models.food;
  * compare nutritional content to other quantities. For example, how to compare "1 Can" to "500 mL" of Apple Juice.
  */
 public class Measure {
+    private static final String CONVERSION_FACTORS_TABLE_NAME = "conversion_factors";
+    private static final String MEASURES_TABLE_NAME = "measures";
+    private static final String MEASURES_CONVERSION_FACTORS_VIEW_NAME = "conversion_factors_with_measure_details";
 
     private final int id;
     private final String name;
     private final float conversionValue;
+
+    public static String getMeasuresTableName() {
+        return MEASURES_TABLE_NAME;
+    }
+
+    public static String getConversionFactorsTableName() {
+        return CONVERSION_FACTORS_TABLE_NAME;
+    }
+
+    public static String getConversionFactorsMeasuresTableName() {
+        return MEASURES_CONVERSION_FACTORS_VIEW_NAME;
+    }
 
     /**
      * @param id              The id of the conversion factor.

--- a/src/main/java/meals/models/meal/MealItem.java
+++ b/src/main/java/meals/models/meal/MealItem.java
@@ -86,6 +86,7 @@ public class MealItem implements IRecord {
             case "id" -> id;
             case "meal_id" -> parentMeal.getId();
             case "food_id" -> food.getFoodId();
+            case "measure_id" -> selectedMeasure.getId();
             case "quantity" -> quantity;
             default -> null;
         };
@@ -93,6 +94,6 @@ public class MealItem implements IRecord {
 
     @Override
     public Collection<String> fieldNames() {
-        return List.of("id", "meal_id", "food_id", "quantity");
+        return List.of("id", "meal_id", "food_id", "quantity", "measure_id");
     }
 }

--- a/src/main/java/meals/models/nutrient/Nutrient.java
+++ b/src/main/java/meals/models/nutrient/Nutrient.java
@@ -17,10 +17,16 @@ public class Nutrient {
     private String nutrientName;
 
 
+    /**
+     * @return The name of the table where nutrients are persisted.
+     */
     public static String getTableName() {
         return TABLE_NAME;
     }
 
+    /**
+     * @return The name of the table where nutrient amounts for each food are stored.
+     */
     public static String getNutrientAmountsTableName() {
         return NUTRIENT_AMOUNTS_TABLE_NAME;
     }
@@ -36,6 +42,9 @@ public class Nutrient {
         this.nutrientName = nutrientName;
     }
 
+    /**
+     * @param record The record to construct a nutrient from.
+     */
     public Nutrient(IRecord record) {
         this.nutrientId = (int) record.getValue("id");
         this.nutrientSymbol = (String) record.getValue("symbol");
@@ -44,23 +53,40 @@ public class Nutrient {
     }
 
     // Getters and setters
+
+    /**
+     * @return The ID of the nutrient.
+     */
     public Integer getNutrientId() {
         return nutrientId;
     }
 
+    /**
+     * @return The symbol for the nutrient.
+     */
     public String getNutrientSymbol() {
         return nutrientSymbol;
     }
 
+    /**
+     * @return The units for the nutrient.
+     */
     public String getNutrientUnit() {
         return nutrientUnit;
     }
 
+    /**
+     * @return The name of the nutrient.
+     */
     public String getNutrientName() {
         return nutrientName;
     }
 
     // Domain logic methods
+
+    /**
+     * @return The display nae of the nutrient.
+     */
     public String getDisplayNameWithUnit() {
         String name = nutrientName != null ? nutrientName : "Unknown Nutrient";
         String unit = nutrientUnit != null ? " (" + nutrientUnit + ")" : "";

--- a/src/main/java/meals/models/nutrient/Nutrient.java
+++ b/src/main/java/meals/models/nutrient/Nutrient.java
@@ -9,6 +9,7 @@ import data.IRecord;
  */
 public class Nutrient {
     private static final String TABLE_NAME = "nutrients";
+    private static final String NUTRIENT_AMOUNTS_TABLE_NAME = "nutrient_amounts";
 
     private Integer nutrientId;
     private String nutrientSymbol;
@@ -18,6 +19,10 @@ public class Nutrient {
 
     public static String getTableName() {
         return TABLE_NAME;
+    }
+
+    public static String getNutrientAmountsTableName() {
+        return NUTRIENT_AMOUNTS_TABLE_NAME;
     }
 
     /**

--- a/src/main/java/meals/models/nutrient/Nutrient.java
+++ b/src/main/java/meals/models/nutrient/Nutrient.java
@@ -1,16 +1,24 @@
 package meals.models.nutrient;
 
 
+import data.IRecord;
+
 /**
  * Represents a nutrient entity (e.g., "PROTEIN", "CALCIUM", "VITAMIN C").
  * This class implements IRecord to integrate with the database layer.
  */
 public class Nutrient {
+    private static final String TABLE_NAME = "nutrients";
+
     private Integer nutrientId;
     private String nutrientSymbol;
     private String nutrientUnit;
     private String nutrientName;
 
+
+    public static String getTableName() {
+        return TABLE_NAME;
+    }
 
     /**
      * Constructor for creating a nutrient with all details.
@@ -21,6 +29,13 @@ public class Nutrient {
         this.nutrientSymbol = nutrientSymbol;
         this.nutrientUnit = nutrientUnit;
         this.nutrientName = nutrientName;
+    }
+
+    public Nutrient(IRecord record) {
+        this.nutrientId = (int) record.getValue("id");
+        this.nutrientSymbol = (String) record.getValue("symbol");
+        this.nutrientUnit = (String) record.getValue("unit");
+        this.nutrientName = (String) record.getValue("unit");
     }
 
     // Getters and setters

--- a/src/main/java/meals/services/QueryFoodGroupsService.java
+++ b/src/main/java/meals/services/QueryFoodGroupsService.java
@@ -1,0 +1,66 @@
+package meals.services;
+
+import data.Comparison;
+import data.DatabaseException;
+import data.IRecord;
+import data.SelectQuery;
+import meals.models.food.FoodGroup;
+import shared.AppBackend;
+
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class QueryFoodGroupsService {
+    private static final String QUERY_FOOD_GROUP_SERVICE_ERROR_MESSAGE = "An error occurred when fetching food groups";
+
+    private static final Map<Integer, FoodGroup> cache = new TreeMap<>();
+
+    public static class QueryFoodGroupServiceException extends Exception {
+        public QueryFoodGroupServiceException(String errorMessage) {
+            super(errorMessage);
+        }
+    }
+
+    private static QueryFoodGroupsService instance;
+
+    private QueryFoodGroupsService() {}
+
+    public static QueryFoodGroupsService instance() {
+        if (instance == null) instance = new QueryFoodGroupsService();
+        return instance;
+    }
+
+    public List<FoodGroup> fetchAll() throws QueryFoodGroupServiceException {
+        // if values are in the cache, then avoid a database call
+        if (!cache.isEmpty()) return cache.values().stream().toList();
+        // otherwise query the database
+        try {
+            List<IRecord> records = AppBackend.db().execute(new SelectQuery(FoodGroup.getTableName()));
+            List<FoodGroup> foodGroups = records.stream().map(FoodGroup::new).toList();
+            // update cache
+            for (FoodGroup foodGroup : foodGroups) cache.put(foodGroup.getFoodGroupId(), foodGroup);
+            return foodGroups;
+        } catch (DatabaseException e) {
+            throw new QueryFoodGroupServiceException(QUERY_FOOD_GROUP_SERVICE_ERROR_MESSAGE);
+        }
+    }
+
+    public FoodGroup findById(int id) throws QueryFoodGroupServiceException {
+        // if value in the cache, use the cache
+        if (cache.containsKey(id)) return cache.get(id);
+        // otherwise, query the database
+        try {
+            IRecord record = AppBackend.db().execute(
+                    new SelectQuery(FoodGroup.getTableName())
+                            .filter("id", Comparison.EQUAL, id)
+            ).getFirst();
+            FoodGroup foodGroup = new FoodGroup(record);
+            // update cache
+            cache.put(id, foodGroup);
+            return foodGroup;
+        } catch (DatabaseException e) {
+            throw new QueryFoodGroupServiceException(QUERY_FOOD_GROUP_SERVICE_ERROR_MESSAGE);
+        }
+    }
+}

--- a/src/main/java/meals/services/QueryFoodGroupsService.java
+++ b/src/main/java/meals/services/QueryFoodGroupsService.java
@@ -1,6 +1,5 @@
 package meals.services;
 
-import data.Comparison;
 import data.DatabaseException;
 import data.IRecord;
 import data.SelectQuery;
@@ -11,11 +10,21 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+/**
+ * Service that queries the database and builds food group instances.
+ * Caches query results.
+ * Because fod groups are immutable and there are a small number of them,
+ * it makes sense for these to be cached in memory rather than querying the database each time.
+ */
 public class QueryFoodGroupsService {
     private static final String QUERY_FOOD_GROUP_SERVICE_ERROR_MESSAGE = "An error occurred when fetching food groups";
 
+    // use a tree map for caching to allow traversing records by ascending id as if returned form the database
     private static final Map<Integer, FoodGroup> cache = new TreeMap<>();
 
+    /**
+     * Exception raised if an error occurs while performing a service.
+     */
     public static class QueryFoodGroupServiceException extends Exception {
         public QueryFoodGroupServiceException(String errorMessage) {
             super(errorMessage);
@@ -26,11 +35,18 @@ public class QueryFoodGroupsService {
 
     private QueryFoodGroupsService() {}
 
+    /**
+     * @return The singleton instance representing the service.
+     */
     public static QueryFoodGroupsService instance() {
         if (instance == null) instance = new QueryFoodGroupsService();
         return instance;
     }
 
+    /**
+     * @return A list of all food groups.
+     * @throws QueryFoodGroupServiceException Thrown if an error occurs while fetching records.
+     */
     public List<FoodGroup> fetchAll() throws QueryFoodGroupServiceException {
         // if values are in the cache, then avoid a database call
         if (!cache.isEmpty()) return cache.values().stream().toList();
@@ -46,21 +62,15 @@ public class QueryFoodGroupsService {
         }
     }
 
+    /**
+     * Fetches the food group with the specified ID.
+     * @param id The id of the food group to query for.
+     * @return The food group with the specified id.
+     * @throws QueryFoodGroupServiceException Thrown if an error occurs when executing the service.
+     */
     public FoodGroup findById(int id) throws QueryFoodGroupServiceException {
-        // if value in the cache, use the cache
         if (cache.containsKey(id)) return cache.get(id);
-        // otherwise, query the database
-        try {
-            IRecord record = AppBackend.db().execute(
-                    new SelectQuery(FoodGroup.getTableName())
-                            .filter("id", Comparison.EQUAL, id)
-            ).getFirst();
-            FoodGroup foodGroup = new FoodGroup(record);
-            // update cache
-            cache.put(id, foodGroup);
-            return foodGroup;
-        } catch (DatabaseException e) {
-            throw new QueryFoodGroupServiceException(QUERY_FOOD_GROUP_SERVICE_ERROR_MESSAGE);
-        }
+        QueryFoodGroupsService.instance().fetchAll(); // load all data into cache
+        return cache.get(id);
     }
 }

--- a/src/main/java/meals/services/QueryFoodsService.java
+++ b/src/main/java/meals/services/QueryFoodsService.java
@@ -1,0 +1,77 @@
+package meals.services;
+
+import data.Comparison;
+import data.DatabaseException;
+import data.IRecord;
+import data.SelectQuery;
+import meals.models.food.Food;
+import meals.models.food.FoodGroup;
+import meals.models.food.Measure;
+import shared.AppBackend;
+
+import java.util.*;
+
+public class QueryFoodsService {
+    private static final String QUERY_FOODS_SERVICE_ERROR_MESSAGE = "An error occurred when fetching foods.";
+
+    public static class QueryFoodsServiceException extends Exception {
+        public QueryFoodsServiceException(String errorMessage) {
+            super(errorMessage);
+        }
+    }
+
+    private static QueryFoodsService instance;
+
+    private QueryFoodsService() {
+    }
+
+    public static QueryFoodsService instance() {
+        if (instance == null) instance = new QueryFoodsService();
+        return instance;
+    }
+
+    public List<Food> fetchAll() throws QueryFoodsServiceException {
+        try {
+            List<IRecord> records = AppBackend.db().execute(new SelectQuery(Food.getTableName()));
+            List<Food> foods = new ArrayList<>();
+            for (IRecord record : records) foods.add(buildFoodFromRecord(record));
+            return foods;
+        } catch (DatabaseException | QueryFoodGroupsService.QueryFoodGroupServiceException e) {
+            throw new QueryFoodsServiceException(QUERY_FOODS_SERVICE_ERROR_MESSAGE);
+        }
+    }
+
+    public Food findById(int id) throws QueryFoodsServiceException {
+        try {
+            SelectQuery query = new SelectQuery(Food.getTableName()).filter("id", Comparison.EQUAL, id);
+            IRecord record = AppBackend.db().execute(query).getFirst();
+            return buildFoodFromRecord(record);
+        } catch (DatabaseException | QueryFoodGroupsService.QueryFoodGroupServiceException e) {
+            throw new QueryFoodsServiceException(QUERY_FOODS_SERVICE_ERROR_MESSAGE);
+        }
+    }
+
+    private static Food buildFoodFromRecord(IRecord food) throws QueryFoodGroupsService.QueryFoodGroupServiceException, DatabaseException {
+        int foodId = (int) food.getValue("id");
+        String description = (String) food.getValue("description");
+        int foodGroupId = (int) food.getValue("food_group_id");
+        FoodGroup foodGroup = QueryFoodGroupsService.instance().findById(foodGroupId);
+        // TO DO: load nutrients
+        return new Food(foodId, description, foodGroup, new HashMap<>(), getMeasures(foodId));
+    }
+
+    private static List<Measure> getMeasures(int foodId) throws DatabaseException {
+        SelectQuery query = new SelectQuery(Measure.getConversionFactorsMeasuresTableName())
+                .filter("food_id", Comparison.EQUAL, foodId);
+        List<IRecord> records = AppBackend.db().execute(query);
+        List<Measure> measures = new ArrayList<>();
+        for (IRecord measureRecord : records) {
+            int measureId = (int) measureRecord.getValue("measure_id");
+            String measureName = (String) measureRecord.getValue("measure_name");
+            // we are fine with losing precision because the value is constant and a small number of decimal places
+            Double conversionFactorValue = (Double) measureRecord.getValue("conversion_factor_value");
+            measures.add(new Measure(measureId, measureName, conversionFactorValue.floatValue()));
+        }
+        return measures;
+    }
+}

--- a/src/main/java/meals/services/QueryFoodsService.java
+++ b/src/main/java/meals/services/QueryFoodsService.java
@@ -12,9 +12,15 @@ import shared.AppBackend;
 
 import java.util.*;
 
+/**
+ * Service that queries foods.
+ */
 public class QueryFoodsService {
     private static final String QUERY_FOODS_SERVICE_ERROR_MESSAGE = "An error occurred when fetching foods.";
 
+    /**
+     * Exception raised if an error occurs while executing the service.
+     */
     public static class QueryFoodsServiceException extends Exception {
         public QueryFoodsServiceException(String errorMessage) {
             super(errorMessage);
@@ -26,11 +32,19 @@ public class QueryFoodsService {
     private QueryFoodsService() {
     }
 
+    /**
+     * @return Singleton instance of the service.
+     */
     public static QueryFoodsService instance() {
         if (instance == null) instance = new QueryFoodsService();
         return instance;
     }
 
+    /**
+     * Returns a list of all foods.
+     * @return A list of all foods in the database.
+     * @throws QueryFoodsServiceException Thrown if an error occurs while executing the service.
+     */
     public List<Food> fetchAll() throws QueryFoodsServiceException {
         try {
             List<IRecord> records = AppBackend.db().execute(new SelectQuery(Food.getTableName()));
@@ -43,6 +57,12 @@ public class QueryFoodsService {
         }
     }
 
+    /**
+     * Queries for the food with the specified id.
+     * @param id The id of the food to query for.
+     * @return The food with the specified id.
+     * @throws QueryFoodsServiceException Thrown if an error occurs while executing the service.
+     */
     public Food findById(int id) throws QueryFoodsServiceException {
         try {
             SelectQuery query = new SelectQuery(Food.getTableName()).filter("id", Comparison.EQUAL, id);
@@ -54,6 +74,11 @@ public class QueryFoodsService {
         }
     }
 
+    /**
+     * Builds a food instance from a database record.
+     * @param food The raw data of the food.
+     * @return The food instance corresponding to the record.
+     */
     private static Food buildFoodFromRecord(IRecord food) throws QueryFoodGroupsService.QueryFoodGroupServiceException, DatabaseException, QueryNutrientsService.QueryNutrientServiceException {
         int foodId = (int) food.getValue("id");
         String description = (String) food.getValue("description");
@@ -63,6 +88,11 @@ public class QueryFoodsService {
         return new Food(foodId, description, foodGroup, nutrientAmounts, getMeasures(foodId));
     }
 
+    /**
+     * Returns a list of measures for the specified food.
+     * @param foodId The food to find the measures for.
+     * @return The measures used for the specified food.
+     */
     private static List<Measure> getMeasures(int foodId) throws DatabaseException {
         SelectQuery query = new SelectQuery(Measure.getConversionFactorsMeasuresTableName())
                 .filter("food_id", Comparison.EQUAL, foodId);

--- a/src/main/java/meals/services/QueryMealsService.java
+++ b/src/main/java/meals/services/QueryMealsService.java
@@ -121,7 +121,7 @@ public class QueryMealsService {
         Food food = QueryFoodsService.instance().findById(id);
         Float quantity = (Float) mealItemRecord.getValue("quantity");
         Integer measureId = (Integer) mealItemRecord.getValue("measure_id");
-        // we know the measure belonging to the meal item also belong to the food,
+        // we know the measure belonging to the meal item also belongs to the food,
         // so we can search the list of measures for the food instead of querying the database
         Measure measure = food.getPossibleMeasures()
                 .stream()

--- a/src/main/java/meals/services/QueryNutrientsService.java
+++ b/src/main/java/meals/services/QueryNutrientsService.java
@@ -1,0 +1,67 @@
+package meals.services;
+
+import data.Comparison;
+import data.DatabaseException;
+import data.IRecord;
+import data.SelectQuery;
+import meals.models.nutrient.Nutrient;
+import shared.AppBackend;
+
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class QueryNutrientsService {
+    private static final String NUTRIENT_SERVICE_ERROR_MESSAGE = "An error occurred when fetching nutrients";
+
+    private static final Map<Integer, Nutrient> cache = new TreeMap<>();
+
+    public static class QueryNutrientServiceException extends Exception {
+        public QueryNutrientServiceException(String errorMessage) {
+            super(errorMessage);
+        }
+    }
+
+    private static QueryNutrientsService instance;
+
+    private QueryNutrientsService() {
+    }
+
+    public static QueryNutrientsService instance() {
+        if (instance == null) instance = new QueryNutrientsService();
+        return instance;
+    }
+
+    public List<Nutrient> fetchAll() throws QueryNutrientServiceException {
+        // if values are in the cache, then avoid a database call
+        if (!cache.isEmpty()) return cache.values().stream().toList();
+        // otherwise query the database
+        try {
+            List<IRecord> records = AppBackend.db().execute(new SelectQuery(Nutrient.getTableName()));
+            List<Nutrient> nutrients = records.stream().map(Nutrient::new).toList();
+            // update cache
+            for (Nutrient nutrient : nutrients) cache.put(nutrient.getNutrientId(), nutrient);
+            return nutrients;
+        } catch (DatabaseException e) {
+            throw new QueryNutrientServiceException(NUTRIENT_SERVICE_ERROR_MESSAGE);
+        }
+    }
+
+    public Nutrient findById(int id) throws QueryNutrientServiceException {
+        // if value in the cache, use the cache
+        if (cache.containsKey(id)) return cache.get(id);
+        // otherwise, query the database
+        try {
+            IRecord record = AppBackend.db().execute(
+                    new SelectQuery(Nutrient.getTableName())
+                            .filter("id", Comparison.EQUAL, id)
+            ).getFirst();
+            Nutrient nutrient = new Nutrient(record);
+            // update cache
+            cache.put(id, nutrient);
+            return nutrient;
+        } catch (DatabaseException e) {
+            throw new QueryNutrientServiceException(NUTRIENT_SERVICE_ERROR_MESSAGE);
+        }
+    }
+}

--- a/src/main/java/meals/services/QueryNutrientsService.java
+++ b/src/main/java/meals/services/QueryNutrientsService.java
@@ -12,11 +12,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+/**
+ * Service that queries the database and constructs nutrients.
+ * Caches query results. Even if we used the entire CSV, there are a relatively small number of nutrients.
+ * Given that nutrients are immutable and there are a small number, we can cache the results to limit the number
+ * of queries we have to make.
+ */
 public class QueryNutrientsService {
     private static final String QUERY_NUTRIENT_SERVICE_ERROR_MESSAGE = "An error occurred when fetching nutrients";
 
     private static final Map<Integer, Nutrient> cache = new TreeMap<>();
 
+    /**
+     * Exception to be raised when an error occurs when executing the service.
+     */
     public static class QueryNutrientServiceException extends Exception {
         public QueryNutrientServiceException(String errorMessage) {
             super(errorMessage);
@@ -28,11 +37,18 @@ public class QueryNutrientsService {
     private QueryNutrientsService() {
     }
 
+    /**
+     * @return Singleton instance for the service.
+     */
     public static QueryNutrientsService instance() {
         if (instance == null) instance = new QueryNutrientsService();
         return instance;
     }
 
+    /**
+     * @return A list of all nutrients.
+     * @throws QueryNutrientServiceException Thrown if an error occurs when fetching nutrients.
+     */
     public List<Nutrient> fetchAll() throws QueryNutrientServiceException {
         // if values are in the cache, then avoid a database call
         if (!cache.isEmpty()) return cache.values().stream().toList();
@@ -48,24 +64,23 @@ public class QueryNutrientsService {
         }
     }
 
+    /**
+     * Returns the nutrient with the specified ID.
+     * @param id The id of the nutrient to query for.
+     * @return The nutrient with the specified ID.
+     */
     public Nutrient findById(int id) throws QueryNutrientServiceException {
         // if value in the cache, use the cache
         if (cache.containsKey(id)) return cache.get(id);
-        // otherwise, query the database
-        try {
-            IRecord record = AppBackend.db().execute(
-                    new SelectQuery(Nutrient.getTableName())
-                            .filter("id", Comparison.EQUAL, id)
-            ).getFirst();
-            Nutrient nutrient = new Nutrient(record);
-            // update cache
-            cache.put(id, nutrient);
-            return nutrient;
-        } catch (DatabaseException e) {
-            throw new QueryNutrientServiceException(QUERY_NUTRIENT_SERVICE_ERROR_MESSAGE);
-        }
+        QueryNutrientsService.instance().fetchAll(); // load all values into the cache
+        return cache.get(id);
     }
 
+    /**
+     * Queries for the nutrients and their quantities for the specified food.
+     * @param foodId The food ID to query nutrient amounts for.
+     * @return The nutrients and their amounts for the specified food.
+     */
     public Map<Nutrient, Float> findNutrientQuantitiesForFood(int foodId) throws QueryNutrientServiceException {
         Map<Nutrient, Float> nutrientAmountsMap = new HashMap<>();
         try {

--- a/src/main/java/meals/ui/LogMealView.java
+++ b/src/main/java/meals/ui/LogMealView.java
@@ -1,12 +1,11 @@
 package meals.ui;
 
 
-import meals.models.MockDataFactory;
 import meals.models.food.Food;
 import meals.models.food.Measure;
 import meals.models.meal.Meal;
+import meals.services.QueryFoodsService;
 import shared.ui.searchable_list.SearchableListView;
-import shared.ui.searchable_list.UIConstants;
 
 import javax.swing.*;
 import java.awt.*;
@@ -99,12 +98,15 @@ public class LogMealView extends JPanel {
      * Helper method to be called in the constructor.
      */
     private void initFoodSearchBox() {
-        // TO DO: use food query service instead of mock food when service implemented
-        // and move this logic to the presenter
+        // TO DO: move this logic to the presenter
         // may need to modify the search box class to support setting the list of items
-        List<Food> foodList = MockDataFactory.generateMockFoods();
-        List<FoodSearchBoxOption> foodSearchBoxOptions = foodList.stream().map(FoodSearchBoxOption::new).toList();
-        foodSearchBox = new SearchableListView<>(foodSearchBoxOptions);
+        try {
+            List<Food> foodList = QueryFoodsService.instance().fetchAll();
+            List<FoodSearchBoxOption> foodSearchBoxOptions = foodList.stream().map(FoodSearchBoxOption::new).toList();
+            foodSearchBox = new SearchableListView<>(foodSearchBoxOptions);
+        } catch (QueryFoodsService.QueryFoodsServiceException e) {
+            showErrorMessage("An error occurred while getting the list of foods: " + e.getMessage());
+        }
     }
 
     /**

--- a/src/test/java/meals/TestQueryFoodGroupsService.java
+++ b/src/test/java/meals/TestQueryFoodGroupsService.java
@@ -1,0 +1,41 @@
+package meals;
+
+import meals.models.food.FoodGroup;
+import meals.services.QueryFoodGroupsService;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestQueryFoodGroupsService {
+    private static final FoodGroup dairyAndEggProducts = new FoodGroup(1, "Dairy and Egg Products");
+
+    @Test
+    void testFetchAll() throws QueryFoodGroupsService.QueryFoodGroupServiceException {
+        List<FoodGroup> foodGroups = QueryFoodGroupsService.instance().fetchAll();
+        assertTrue(foodGroups.size() > 1);  // test multiple records are returned
+        assertEquals(dairyAndEggProducts, foodGroups.getFirst());
+    }
+
+    @Test
+    void testFindById() throws QueryFoodGroupsService.QueryFoodGroupServiceException {
+        FoodGroup foodGroup = QueryFoodGroupsService.instance().findById(1);
+        assertEquals(dairyAndEggProducts, foodGroup);
+    }
+
+    @Test
+    void testFetchAllGetResultFromCache() throws QueryFoodGroupsService.QueryFoodGroupServiceException {
+        QueryFoodGroupsService.instance().fetchAll();
+        List<FoodGroup> foodGroups = QueryFoodGroupsService.instance().fetchAll();
+        assertEquals(dairyAndEggProducts, foodGroups.getFirst());
+    }
+
+    @Test
+    void testFindByIdGetResultFromCache() throws QueryFoodGroupsService.QueryFoodGroupServiceException {
+        QueryFoodGroupsService.instance().findById(1);
+        FoodGroup foodGroup = QueryFoodGroupsService.instance().findById(1);
+        assertEquals(dairyAndEggProducts, foodGroup);
+    }
+}

--- a/src/test/java/meals/TestQueryFoodsService.java
+++ b/src/test/java/meals/TestQueryFoodsService.java
@@ -4,6 +4,7 @@ import meals.models.food.Food;
 import meals.models.food.FoodGroup;
 import meals.models.food.Measure;
 import meals.services.QueryFoodsService;
+import meals.services.QueryNutrientsService;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -20,7 +21,7 @@ public class TestQueryFoodsService {
         );
         FoodGroup foodGroup = new FoodGroup(14, "Beverages");
         return new Food(
-            5589,
+                5589,
                 "Chocolate flavour drink, whey and milk based",
                 foodGroup,
                 Collections.emptyMap(),
@@ -43,7 +44,7 @@ public class TestQueryFoodsService {
     }
 
     @Test
-    void testFindById() throws QueryFoodsService.QueryFoodsServiceException {
+    void testFindById() throws QueryFoodsService.QueryFoodsServiceException, QueryNutrientsService.QueryNutrientServiceException {
         Food chocolateDrink = buildChocolateDrink();
         Food food5589 = QueryFoodsService.instance().findById(5589);
         assertEquals(chocolateDrink.getFoodId(), food5589.getFoodId());
@@ -51,8 +52,10 @@ public class TestQueryFoodsService {
         // associations
         compareFoodGroups(chocolateDrink.getFoodGroup(), food5589.getFoodGroup());
         compareMeasureList(chocolateDrink.getPossibleMeasures(), food5589.getPossibleMeasures());
+        // FATTY ACIDS, MONOUNSATURATED, TOTAL
+        float actualAmount = food5589.getNutrientAmount(QueryNutrientsService.instance().findById(645));
+        assertEquals(0.049F, actualAmount, 0001F);
     }
-
 
     void compareFoodGroups(FoodGroup expectedFoodGroup, FoodGroup actualFoodGroup) {
         assertEquals(expectedFoodGroup.getFoodGroupId(), actualFoodGroup.getFoodGroupId());

--- a/src/test/java/meals/TestQueryFoodsService.java
+++ b/src/test/java/meals/TestQueryFoodsService.java
@@ -1,0 +1,74 @@
+package meals;
+
+import meals.models.food.Food;
+import meals.models.food.FoodGroup;
+import meals.models.food.Measure;
+import meals.services.QueryFoodsService;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestQueryFoodsService {
+    private static Food buildChocolateDrink() {
+        List<Measure> possibleMeasures = List.of(
+                new Measure(341, "100ml", 1.03128f),
+                new Measure(415, "250ml (1 cup)", 2.57819f)
+        );
+        FoodGroup foodGroup = new FoodGroup(14, "Beverages");
+        return new Food(
+            5589,
+                "Chocolate flavour drink, whey and milk based",
+                foodGroup,
+                Collections.emptyMap(),
+                possibleMeasures
+        );
+    }
+
+    @Test
+    void testFetchAll() throws QueryFoodsService.QueryFoodsServiceException {
+        Food chocolateDrink = buildChocolateDrink();
+        List<Food> foods = QueryFoodsService.instance().fetchAll();
+        assertTrue(foods.size() > 1);
+        Food food5589 = foods.stream().filter(food -> food.getFoodId().equals(5589)).toList().getFirst();
+        // basic properties
+        assertEquals(chocolateDrink.getFoodId(), food5589.getFoodId());
+        assertEquals(chocolateDrink.getFoodDescription(), food5589.getFoodDescription());
+        // associations
+        compareFoodGroups(chocolateDrink.getFoodGroup(), food5589.getFoodGroup());
+        compareMeasureList(chocolateDrink.getPossibleMeasures(), food5589.getPossibleMeasures());
+    }
+
+    @Test
+    void testFindById() throws QueryFoodsService.QueryFoodsServiceException {
+        Food chocolateDrink = buildChocolateDrink();
+        Food food5589 = QueryFoodsService.instance().findById(5589);
+        assertEquals(chocolateDrink.getFoodId(), food5589.getFoodId());
+        assertEquals(chocolateDrink.getFoodDescription(), food5589.getFoodDescription());
+        // associations
+        compareFoodGroups(chocolateDrink.getFoodGroup(), food5589.getFoodGroup());
+        compareMeasureList(chocolateDrink.getPossibleMeasures(), food5589.getPossibleMeasures());
+    }
+
+
+    void compareFoodGroups(FoodGroup expectedFoodGroup, FoodGroup actualFoodGroup) {
+        assertEquals(expectedFoodGroup.getFoodGroupId(), actualFoodGroup.getFoodGroupId());
+        assertEquals(expectedFoodGroup.getFoodGroupName(), actualFoodGroup.getFoodGroupName());
+    }
+
+    void compareMeasureList(List<Measure> expectedMeasures, List<Measure> actualMeasures) {
+        assertEquals(expectedMeasures.size(), actualMeasures.size());
+        for (int i = 0; i < expectedMeasures.size(); i++) {
+            compareMeasures(expectedMeasures.get(i), actualMeasures.get(i));
+        }
+    }
+
+    void compareMeasures(Measure expectedMeasure, Measure actualMeasure) {
+        assertEquals(expectedMeasure.getId(), actualMeasure.getId());
+        assertEquals(expectedMeasure.getName(), actualMeasure.getName());
+        assertEquals(expectedMeasure.getConversionValue(), actualMeasure.getConversionValue());
+    }
+}

--- a/src/test/java/meals/TestQueryNutrientsService.java
+++ b/src/test/java/meals/TestQueryNutrientsService.java
@@ -1,0 +1,41 @@
+package meals;
+
+import meals.models.nutrient.Nutrient;
+import meals.services.QueryNutrientsService;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestQueryNutrientsService {
+    private static final Nutrient protein = new Nutrient(203, "PROT", "g", "PROTEIN");
+
+    @Test
+    void testFetchAll() throws QueryNutrientsService.QueryNutrientServiceException {
+        List<Nutrient> nutrients = QueryNutrientsService.instance().fetchAll();
+        assertTrue(nutrients.size() > 1);
+        assertEquals(protein, nutrients.getFirst());
+    }
+
+    @Test
+    void testFindById() throws QueryNutrientsService.QueryNutrientServiceException {
+        Nutrient nutrient203 = QueryNutrientsService.instance().findById(203);
+        assertEquals(protein, nutrient203);
+    }
+
+    @Test
+    void testFetchAllGetResultFromCache() throws QueryNutrientsService.QueryNutrientServiceException {
+        QueryNutrientsService.instance().fetchAll();
+        List<Nutrient> nutrients = QueryNutrientsService.instance().fetchAll();
+        assertEquals(protein, nutrients.getFirst());
+    }
+
+    @Test
+    void testFindByIdGetResultFromCache() throws QueryNutrientsService.QueryNutrientServiceException {
+        QueryNutrientsService.instance().findById(203);
+        Nutrient nutrient203 = QueryNutrientsService.instance().findById(203);
+        assertEquals(protein, nutrient203);
+    }
+}


### PR DESCRIPTION
### Description

Adds services to query nutrients/foods/food-groups.
 
Additionally, saves the selected measure id as part of a meal item and uses real foods for meal logging in the UI instead of mock data.

Rather than adding DAO objects, I opted just to build the objects in services, since I did not feel like this extra layer was adding adding enough value to justify the boiler-plate. We can refactor this if we wanted later with minimal impact, since clients should be going through the service to query objects.

**Follow-ups:** There are some more places throughout the code-base we have to move away from using mock data.

### Testing

✅ Included tests for the services that query nutrition data.
✅ Manual tested in the UI and confirmed meal logging works with real foods, except for one caveat mentioned below.

**Automatic Tests** 

Tests pass locally and in CI.

<img width="500" height="536" alt="Screenshot 2025-07-24 010152" src="https://github.com/user-attachments/assets/30d7a2a2-6249-4f6c-a0e0-123587c0a744" />

**Manual Tests**

**Note:** Some foods do not have ay measures associated with them, so the dropdown appears empty in the UI. This indicates missing CSV data. We can fix this as a follow-up. It doesn't completely break the UI.

```sql
-- 7 foods without any measures
select count(*) from foods f left join conversion_factors_with_measure_details cf on f.id = cf.food_id where cf.food_id is null
```

