### PR TITLE
quick-fix-Food-should-be-fetched-through-food-id-in-MealItem

### DIFF
--- a/src/main/java/meals/services/QueryMealsService.java
+++ b/src/main/java/meals/services/QueryMealsService.java
@@ -118,7 +118,8 @@ public class QueryMealsService {
      */
     private static MealItem buildMealItemForRecord(IRecord mealItemRecord) throws QueryFoodsService.QueryFoodsServiceException {
         Integer id = (Integer) mealItemRecord.getValue("id");
-        Food food = QueryFoodsService.instance().findById(id);
+        Integer foodId = (Integer) mealItemRecord.getValue("food_id");
+        Food food = QueryFoodsService.instance().findById(foodId);
         Float quantity = (Float) mealItemRecord.getValue("quantity");
         Integer measureId = (Integer) mealItemRecord.getValue("measure_id");
         // we know the measure belonging to the meal item also belongs to the food,


### PR DESCRIPTION
### Description

When building MealItem, `Food` object aggregated in `MealItem` should be fetched through `food_id`, not `id` of the `mealItem`.

### Testing

