### PR TITLE
quick-fix-on-Nutrient-class

### DIFF
--- a/src/main/java/meals/models/nutrient/Nutrient.java
+++ b/src/main/java/meals/models/nutrient/Nutrient.java
@@ -49,7 +49,7 @@ public class Nutrient {
         this.nutrientId = (int) record.getValue("id");
         this.nutrientSymbol = (String) record.getValue("symbol");
         this.nutrientUnit = (String) record.getValue("unit");
-        this.nutrientName = (String) record.getValue("unit");
+        this.nutrientName = (String) record.getValue("name");
     }
 
     // Getters and setters


### PR DESCRIPTION
### Description

`nutrientName` should be fetched through [`name`](https://github.com/christopher-dembski/delta/blob/main/src/main/java/csv/nutrition_data/nutrients.csv), not `unit.`

### Testing

